### PR TITLE
Fix/28012 osb mongodb stresses service instances with health requests

### DIFF
--- a/osb-service/src/main/java/de/evoila/cf/broker/backup/BackupCustomServiceImpl.java
+++ b/osb-service/src/main/java/de/evoila/cf/broker/backup/BackupCustomServiceImpl.java
@@ -50,7 +50,7 @@ public class BackupCustomServiceImpl implements BackupCustomService {
 
     @Override
     public Map<String, String> getItems(String serviceInstanceId) throws ServiceInstanceDoesNotExistException,
-            ServiceDefinitionDoesNotExistException, ServiceDefinitionPlanDoesNotExistException {
+            ServiceDefinitionDoesNotExistException, ServiceDefinitionPlanDoesNotExistException, ServiceBrokerException {
         ServiceInstance serviceInstance = serviceInstanceRepository.getServiceInstance(serviceInstanceId);
 
         if(serviceInstance == null || serviceInstance.getHosts().size() <= 0) {
@@ -70,7 +70,7 @@ public class BackupCustomServiceImpl implements BackupCustomService {
                 for (Document database : databases)
                     result.put(database.getString("name"), database.getString("name"));
             } catch (MongoException ex) {
-                new ServiceBrokerException("Could not load databases", ex);
+                throw new ServiceBrokerException("Could not load databases", ex);
             } finally {
                 mongoDbService.close();
             }

--- a/osb-service/src/main/java/de/evoila/cf/broker/backup/BackupCustomServiceImpl.java
+++ b/osb-service/src/main/java/de/evoila/cf/broker/backup/BackupCustomServiceImpl.java
@@ -71,6 +71,8 @@ public class BackupCustomServiceImpl implements BackupCustomService {
                     result.put(database.getString("name"), database.getString("name"));
             } catch (MongoException ex) {
                 new ServiceBrokerException("Could not load databases", ex);
+            } finally {
+                mongoDbService.close();
             }
         } else if (plan.getPlatform().equals(Platform.EXISTING_SERVICE)) {
             result.put(MongoDBUtils.dbName(serviceInstance.getId()), MongoDBUtils.dbName(serviceInstance.getId()));

--- a/osb-service/src/main/java/de/evoila/cf/broker/custom/mongodb/MongoDBBindingService.java
+++ b/osb-service/src/main/java/de/evoila/cf/broker/custom/mongodb/MongoDBBindingService.java
@@ -103,6 +103,7 @@ public class MongoDBBindingService extends BindingServiceImpl {
 
         mongoDbService.mongoClient().getDatabase(database)
                 .runCommand(new BasicDBObject("dropUser", bindingCredentials.getUsername()));
+        mongoDbService.close();
 
         credentialStore.deleteCredentials(serviceInstance, binding.getId());
     }

--- a/osb-service/src/main/java/de/evoila/cf/cpi/existing/MongoDbExistingServiceFactory.java
+++ b/osb-service/src/main/java/de/evoila/cf/cpi/existing/MongoDbExistingServiceFactory.java
@@ -59,6 +59,7 @@ public class MongoDbExistingServiceFactory extends ExistingServiceFactory {
         MongoDBService mongoDbService = mongoDBCustomImplementation.connection(serviceInstance, plan, null);
 
         mongoDBCustomImplementation.createDatabase(mongoDbService, MongoDBUtils.dbName(serviceInstance.getId()));
+        mongoDbService.close();
 
         return serviceInstance;
     }
@@ -68,6 +69,7 @@ public class MongoDbExistingServiceFactory extends ExistingServiceFactory {
         MongoDBService mongoDbService = mongoDBCustomImplementation.connection(serviceInstance, plan, null);
 
         mongoDBCustomImplementation.deleteDatabase(mongoDbService, MongoDBUtils.dbName(serviceInstance.getId()));
+        mongoDbService.close();
 
         if(existingEndpointBean.getBackupCredentials() != null) {
             credentialStore.deleteCredentials(serviceInstance, DefaultCredentialConstants.BACKUP_AGENT_CREDENTIALS);


### PR DESCRIPTION
We have fixed an issue which does not close certain connections to MongoDB, e.g. during binding. This resulted in more and more open connections on the MongoDB server side, which eventually led to an overload of the server.